### PR TITLE
[TASK] faq-with-tags module - Tags will be hidden if only 1 FAQ group is set (+ add inline help text) - fix of initial FAQ group text field

### DIFF
--- a/theme/modules/faq-with-tags.module/_locales/en/messages.json
+++ b/theme/modules/faq-with-tags.module/_locales/en/messages.json
@@ -34,6 +34,11 @@
     "description" : null,
     "placeholders" : null
   },
+  "faq_group.default.tag.text" : {
+    "message" : "Tag text",
+    "description" : null,
+    "placeholders" : null
+  },
   "faq_group.heading.default.text" : {
     "message" : "Heading text",
     "description" : null,
@@ -45,7 +50,7 @@
     "placeholders" : null
   },
   "faq_group.inline_help_text" : {
-    "message" : "",
+    "message" : "NOTE: Tags will be hidden if only 1 FAQ group is set.",
     "description" : null,
     "placeholders" : null
   },

--- a/theme/modules/faq-with-tags.module/fields.json
+++ b/theme/modules/faq-with-tags.module/fields.json
@@ -528,6 +528,7 @@
   "name" : "faq_group",
   "display_width" : null,
   "label" : "FAQ group",
+  "inline_help_text" : "NOTE: Tags will be hidden if only 1 FAQ group is set.",
   "required" : false,
   "locked" : false,
   "occurrence" : {
@@ -648,8 +649,9 @@
   "group_occurrence_meta" : null,
   "type" : "group",
   "default" : [ {
-    "field_group" : {
-      "faq_tag" : "Tag text"
+    "field_group" : {},
+    "tag" : {
+      "text" : "Tag text"
     },
     "questions" : [ {
       "text" : {

--- a/theme/modules/faq-with-tags.module/module.css
+++ b/theme/modules/faq-with-tags.module/module.css
@@ -26,12 +26,6 @@
   gap: 10px;
 }
 
-/* horizontal lines */
-.faq-with-tags-module__details,
-.faq-with-tags-module__button-tags {
-  border-bottom: 1px solid #dbdbdb;
-}
-
 /* Tag containers destination */
 .faq-with-tags-module__tag {
   display: none;
@@ -39,6 +33,7 @@
 
 .faq-with-tags-module__tag.show {
   display: block;
+  border-top: 1px solid #dbdbdb;
 }
 
 /* Question */
@@ -72,6 +67,7 @@
 }
 
 .faq-with-tags-module__details {
+  border-bottom: 1px solid #dbdbdb;
   margin-bottom: 20px;
 }
 

--- a/theme/modules/faq-with-tags.module/module.css
+++ b/theme/modules/faq-with-tags.module/module.css
@@ -14,8 +14,12 @@
 
 /* Tags container (source) */
 .faq-with-tags-module__button-tags {
-  padding-bottom: 50px;
+  display: none;
+}
+
+.faq-with-tags-module__button-tags.show {
   display: flex;
+  padding-bottom: 50px;
   flex-direction: row;
   flex-wrap: wrap;
   align-items: center;

--- a/theme/modules/faq-with-tags.module/module.html
+++ b/theme/modules/faq-with-tags.module/module.html
@@ -47,7 +47,7 @@
     data-active-tag="{{ module.style.tag.active_tag }}"
     data-inactive-tag="{{ module.style.tag.inactive_tag }}"
   >
-    <div class="faq-with-tags-module__button-tags">
+    <div class="faq-with-tags-module__button-tags {{ 'show' if module.faq_group|length > 1 }}">
       {% for group in module.faq_group %}
         <button data-id="{{module_id}}{{ loop.index0 }}" class="btn-link {{ '{{ module.style.tag.active_tag }}' if loop.index0 == 0 else '{{ module.style.tag.inactive_tag }}' }} btn-regular">
           {{text_macros.render_text_tmpl(group.tag, none, module, tagOptions)}}


### PR DESCRIPTION
- Tags will be hidden if only 1 FAQ group is set (+ add inline help text)
- fix of initial FAQ group text field

# New Pull Request checklist

## Please check if your PR fulfills the following requirements

- [x] Contributing: <https://github.com/resultify/.github/blob/master/CONTRIBUTING.md>
- [x] Coding Rules: <https://github.com/resultify/.github/blob/master/CONTRIBUTING.md#coding-rules>
- [x] Commit message conventions: <https://github.com/resultify/.github/blob/master/CONTRIBUTING.md#commit-message-guidelines>

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x" inside brackets -->

- [ ] [FEATURE] - A new feature
- [ ] [BUGFIX] - A bug fix
- [x] [TASK] - Any task, which is not a **new feature** or **bugfix**
- [ ] [TEST] - Adding missing tests
- [ ] [DOC] - Documentation only changes
- [ ] [WIP] - Work in progress tag, should not be present when creating pull requests

## Breaking change

Does this PR introduce a breaking change?

<!-- Please check the one that applies to this PR using "x" inside brackets -->

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please add a [!!!] label at the beginning of the commit message. -->
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Issue references

Issue Number: #...

## Description
<!-- Please add a context and reasoning around your changes, to help us merge quickly. -->
This makes it possible to use it like a regular FAQ (without tags) too but with the styling of this module.
Finally found the issue why the default FAQ group text was blank.