### PR TITLE
[TASK] update dotlottie-web to 0.41.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "4.0.1",
       "license": "MIT",
       "dependencies": {
-        "@lottiefiles/dotlottie-web": "~0.36.0",
+        "@lottiefiles/dotlottie-web": "~0.41.0",
         "@splidejs/splide": "^4.1.4",
         "@splidejs/splide-extension-auto-scroll": "^0.5.3",
         "@splidejs/splide-extension-intersection": "^0.2.0",
@@ -599,9 +599,10 @@
       "dev": true
     },
     "node_modules/@lottiefiles/dotlottie-web": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@lottiefiles/dotlottie-web/-/dotlottie-web-0.36.1.tgz",
-      "integrity": "sha512-KvxOH5Msk0Ivqpgq4p1DGo1IG2XPX4kEVkhssTaOUEvoeCxDLru+DlbUzwG8b5JcJwEBmrAMzCNzCTmn+uMFxQ=="
+      "version": "0.41.0",
+      "resolved": "https://registry.npmjs.org/@lottiefiles/dotlottie-web/-/dotlottie-web-0.41.0.tgz",
+      "integrity": "sha512-hJR3zN9DiQkNjEA0+OJbuPJPXZtbySrfYa61WD5qFc7dBPHGDUaSC6APvwM2FSrzPy0AU4nrOPfExEe6VNznkg==",
+      "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "uploadDb": "cmslib --uploadDb"
   },
   "dependencies": {
-    "@lottiefiles/dotlottie-web": "~0.36.0",
+    "@lottiefiles/dotlottie-web": "~0.41.0",
     "@splidejs/splide": "^4.1.4",
     "@splidejs/splide-extension-auto-scroll": "^0.5.3",
     "@splidejs/splide-extension-intersection": "^0.2.0",


### PR DESCRIPTION
# New Pull Request checklist

## Please check if your PR fulfills the following requirements

- [x] Contributing: <https://github.com/resultify/.github/blob/master/CONTRIBUTING.md>
- [x] Coding Rules: <https://github.com/resultify/.github/blob/master/CONTRIBUTING.md#coding-rules>
- [x] Commit message conventions: <https://github.com/resultify/.github/blob/master/CONTRIBUTING.md#commit-message-guidelines>

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x" inside brackets -->

- [ ] [FEATURE] - A new feature
- [ ] [BUGFIX] - A bug fix
- [x] [TASK] - Any task, which is not a **new feature** or **bugfix**
- [ ] [TEST] - Adding missing tests
- [ ] [DOC] - Documentation only changes
- [ ] [WIP] - Work in progress tag, should not be present when creating pull requests

## Breaking change

Does this PR introduce a breaking change?

<!-- Please check the one that applies to this PR using "x" inside brackets -->

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please add a [!!!] label at the beginning of the commit message. -->
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Issue references

Issue Number: #...

## Description
I've noticed lottie animations uses quite a bit of CPU. Fortunately it improves quite a bit with newer version. Maybe this one is the reason: https://github.com/LottieFiles/dotlottie-web/releases/tag/%40lottiefiles%2Fdotlottie-web%400.39.0-beta.9

0.36.0
<!-- Please add a context and reasoning around your changes, to help us merge quickly. -->
![Screenshot From 2025-03-28 10-22-24](https://github.com/user-attachments/assets/2acb1372-c124-433e-803b-0193ac3bd811)

0.41.0
![Screenshot From 2025-03-28 10-23-30](https://github.com/user-attachments/assets/61dce33e-8e02-43e3-8234-a42e96bf2596)
