### PR TITLE
[BUGFIX] site-header, site-header-with-mega-menu: replace 'module.style.menu.links.font.style' output with individual .styles plus individual checks, to not break the generated css output.

### DIFF
--- a/theme/modules/site-header-with-mega-menu.module/module.html
+++ b/theme/modules/site-header-with-mega-menu.module/module.html
@@ -742,10 +742,19 @@
 
     .main-nav__list-item-link {
       justify-content: flex-start;
-      {% if link_font.font != 'null' %}
-        {{link_font.style}};
-      {% else %}
-        {{link_font.style}};
+      {% if link_font.styles.font-weight %}
+        font-weight: {{link_font.styles.font-weight}};
+      {% endif %}
+      {% if link_font.styles.text-decoration %}
+        text-decoration: {{link_font.styles.text-decoration}};
+      {% endif %}
+      {% if link_font.styles.font-family %}
+        font-family: {{link_font.styles.font-family}};
+      {% endif %}
+      {% if link_font.styles.font-style %}
+        font-style: {{link_font.styles.font-style}};
+      {% endif %}
+      {% if link_font.font == 'null' %}
         font-family: var(--system-fonts);
       {% endif %}
       {% if link_font.color %}
@@ -766,7 +775,18 @@
 
     .main-nav__list--sublevel .main-nav__title {
       {{module.style.menu.dropdown.links.spacing.css}}
-      {{link_font.style}};
+      {% if link_font.styles.font-weight %}
+        font-weight: {{link_font.styles.font-weight}};
+      {% endif %}
+      {% if link_font.styles.text-decoration %}
+        text-decoration: {{link_font.styles.text-decoration}};
+      {% endif %}
+      {% if link_font.styles.font-family %}
+        font-family: {{link_font.styles.font-family}};
+      {% endif %}
+      {% if link_font.styles.font-style %}
+        font-style: {{link_font.styles.font-style}};
+      {% endif %}
       {% if link_font.size %}
         {# use mega_menu.first_level_title_font_size #}
         font-size: calc({{link_font.size ~ 'px'}} * ({{ module.menu.mega_menu.first_level_title_font_size }} * 0.01));
@@ -899,10 +919,19 @@
     {% endif %}
 
     .header-language-btn {
-      {% if lang_link_font.font != 'null' %}
-        {{lang_link_font.style}};
-      {% else %}
-        {{lang_link_font.style}};
+      {% if lang_link_font.styles.font-weight %}
+        font-weight: {{lang_link_font.styles.font-weight}};
+      {% endif %}
+      {% if lang_link_font.styles.text-decoration %}
+        text-decoration: {{lang_link_font.styles.text-decoration}};
+      {% endif %}
+      {% if lang_link_font.styles.font-family %}
+        font-family: {{lang_link_font.styles.font-family}};
+      {% endif %}
+      {% if lang_link_font.styles.font-style %}
+        font-style: {{lang_link_font.styles.font-style}};
+      {% endif %}
+      {% if lang_link_font.font == 'null' %}
         font-family: var(--system-fonts);
       {% endif %}
       {% if lang_link_font.color %}

--- a/theme/modules/site-header-with-mega-menu.module/module.html
+++ b/theme/modules/site-header-with-mega-menu.module/module.html
@@ -774,7 +774,6 @@
     }
 
     .main-nav__list--sublevel .main-nav__title {
-      {{module.style.menu.dropdown.links.spacing.css}}
       {% if link_font.styles.font-weight %}
         font-weight: {{link_font.styles.font-weight}};
       {% endif %}
@@ -791,6 +790,7 @@
         {# use mega_menu.first_level_title_font_size #}
         font-size: calc({{link_font.size ~ 'px'}} * ({{ module.menu.mega_menu.first_level_title_font_size }} * 0.01));
       {% endif %}
+      {{module.style.menu.dropdown.links.spacing.css}}
     }
 
     .main-nav__list--sublevel .main-nav__description {

--- a/theme/modules/site-header.module/module.html
+++ b/theme/modules/site-header.module/module.html
@@ -360,10 +360,19 @@
 
     .main-nav__list-item-link {
       justify-content: flex-start;
-      {% if link_font.font != 'null' %}
-        {{link_font.style}};
-      {% else %}
-        {{link_font.style}};
+      {% if link_font.styles.font-weight %}
+        font-weight: {{link_font.styles.font-weight}};
+      {% endif %}
+      {% if link_font.styles.text-decoration %}
+        text-decoration: {{link_font.styles.text-decoration}};
+      {% endif %}
+      {% if link_font.styles.font-family %}
+        font-family: {{link_font.styles.font-family}};
+      {% endif %}
+      {% if link_font.styles.font-style %}
+        font-style: {{link_font.styles.font-style}};
+      {% endif %}
+      {% if link_font.font == 'null' %}
         font-family: var(--system-fonts);
       {% endif %}
       {% if link_font.color %}
@@ -473,10 +482,19 @@
     {% endif %}
 
     .header-language-btn {
-      {% if lang_link_font.font != 'null' %}
-        {{lang_link_font.style}};
-      {% else %}
-        {{lang_link_font.style}};
+      {% if lang_link_font.styles.font-weight %}
+        font-weight: {{lang_link_font.styles.font-weight}};
+      {% endif %}
+      {% if lang_link_font.styles.text-decoration %}
+        text-decoration: {{lang_link_font.styles.text-decoration}};
+      {% endif %}
+      {% if lang_link_font.styles.font-family %}
+        font-family: {{lang_link_font.styles.font-family}};
+      {% endif %}
+      {% if lang_link_font.styles.font-style %}
+        font-style: {{lang_link_font.styles.font-style}};
+      {% endif %}
+      {% if lang_link_font.font == 'null' %}
         font-family: var(--system-fonts);
       {% endif %}
       {% if lang_link_font.color %}


### PR DESCRIPTION


# New Pull Request checklist

## Please check if your PR fulfills the following requirements

- [x] Contributing: <https://github.com/resultify/.github/blob/master/CONTRIBUTING.md>
- [x] Coding Rules: <https://github.com/resultify/.github/blob/master/CONTRIBUTING.md#coding-rules>
- [x] Commit message conventions: <https://github.com/resultify/.github/blob/master/CONTRIBUTING.md#commit-message-guidelines>

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x" inside brackets -->

- [ ] [FEATURE] - A new feature
- [x] [BUGFIX] - A bug fix
- [ ] [TASK] - Any task, which is not a **new feature** or **bugfix**
- [ ] [TEST] - Adding missing tests
- [ ] [DOC] - Documentation only changes
- [ ] [WIP] - Work in progress tag, should not be present when creating pull requests

## Breaking change

Does this PR introduce a breaking change?

<!-- Please check the one that applies to this PR using "x" inside brackets -->

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please add a [!!!] label at the beginning of the commit message. -->
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Issue references

Issue Number: #...

## Description
<!-- Please add a context and reasoning around your changes, to help us merge quickly. -->
Should not break anything on site-header and site-header-with-megamenu, but should work better in cases where some style values are missing.