### PR TITLE
[BUGFIX] search-results system template: add 'show_title' to search-results-module to mitigate 'hNaN' heading error

### DIFF
--- a/theme/templates/system/search-results.html
+++ b/theme/templates/system/search-results.html
@@ -1,0 +1,36 @@
+<!--
+  templateType: search_results_page
+  isAvailableForNewContent: true
+  label: Search results
+  screenshotPath: ../../images/template-previews/search-results.jpg
+-->
+
+{% set template_css = '../../css/templates/system/search-results.css' %}
+{% extends '../layouts/base.html' %}
+{% set pageTitle = "Search results" %}
+
+{% block body %}
+  <div class="search-results_wrp system-page_wrp">
+    <div class="search-results system-page">
+
+      <div class="search-results__heading">
+        {% module_block module 'richtext' path="../../modules/richtext" %}
+          {% module_attribute "rich_text" %}
+            <h1>Results for "{{request.query_dict.term|escape}}"</h1>
+          {% end_module_attribute %}
+        {% end_module_block %}
+      </div>
+
+      <div class="search-results__list_wrp">
+        {% module 'search_results'
+          extra_classes="search-results__list",
+          path='@hubspot/search_results',
+          title={
+            "show_title" : true
+          }
+        %}
+      </div>
+
+    </div>
+  </div>
+{% endblock body %}


### PR DESCRIPTION
# New Pull Request checklist

## Please check if your PR fulfills the following requirements

- [ ] Contributing: <https://github.com/resultify/.github/blob/master/CONTRIBUTING.md>
- [ ] Coding Rules: <https://github.com/resultify/.github/blob/master/CONTRIBUTING.md#coding-rules>
- [ ] Commit message conventions: <https://github.com/resultify/.github/blob/master/CONTRIBUTING.md#commit-message-guidelines>

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x" inside brackets -->

- [ ] [FEATURE] - A new feature
- [x] [BUGFIX] - A bug fix
- [ ] [TASK] - Any task, which is not a **new feature** or **bugfix**
- [ ] [TEST] - Adding missing tests
- [ ] [DOC] - Documentation only changes
- [ ] [WIP] - Work in progress tag, should not be present when creating pull requests

## Breaking change

Does this PR introduce a breaking change?

<!-- Please check the one that applies to this PR using "x" inside brackets -->

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please add a [!!!] label at the beginning of the commit message. -->
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Issue references

Issue Number: #...

## Description
<!-- Please add a context and reasoning around your changes, to help us merge quickly. -->
![image](https://github.com/user-attachments/assets/b5be54dd-ebd6-46d9-9df7-b1c01ae70379)
Hubspots search_results module does not produce a correct heading tag with the current template inclusion from nimbly-lite. The heading becomes "hnan". By adding
```title={
            "show_title" : true
          }
```
it works again.

![image](https://github.com/user-attachments/assets/db40b765-8169-493b-b38b-d993eb795400)
